### PR TITLE
Remove Bad Apostrophe from "its flipped reflection."

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@ $(function() {
 ...
 &lt;img id=&quot;lake-img&quot; src=&quot;lake.png&quot; style=&quot;display: none;&quot;/&gt;
       </pre>
-      <p>Lake.js takes an img element and inserts a canvas element displaying the image and it's flipped reflection directly after the img element.</p>
+      <p>Lake.js takes an img element and inserts a canvas element displaying the image and its flipped reflection directly after the img element.</p>
       <p>The new canvas element will be the same width as the original image and double the height.</p>
       <p>
         <ul>


### PR DESCRIPTION
I run a grammar blog at BadApostrophes.com, and unfortunately, I've spotted an unnecessary apostrophe in your Lake.js demo page.  In the description, "and it's flipped reflection" doesn't need an apostrophe.

I've written this up at http://www.badapostrophes.com/2012/04/its-a-trilogy-reflecting-on-mediocrity/ , but I'll be happy to update my post if you merge my change and update the page.

Thanks,
Curtis Gibby
BadApostrophes.com
